### PR TITLE
Chore: refactoring ExpirationDuration

### DIFF
--- a/apps/jan-api-gateway/application/app/domain/auth/auth_service.go
+++ b/apps/jan-api-gateway/application/app/domain/auth/auth_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
@@ -34,6 +35,9 @@ func NewAuthService(
 	}
 }
 
+const AccessTokenExpirationDuration = 15 * time.Minute
+const RefreshTokenExpirationDuration = 7 * 24 * time.Hour
+
 type UserContextKey string
 
 const (
@@ -57,7 +61,6 @@ func (s *AuthService) JWTAuthMiddleware() gin.HandlerFunc {
 		if !ok {
 			return
 		}
-
 		SetUserIDToContext(reqCtx, userId)
 		reqCtx.Next()
 	}

--- a/apps/jan-api-gateway/application/app/interfaces/http/http_server.go
+++ b/apps/jan-api-gateway/application/app/interfaces/http/http_server.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 
 	"github.com/gin-gonic/gin"
@@ -24,16 +23,6 @@ type HttpServer struct {
 func (s *HttpServer) bindSwagger() {
 	g := s.engine.Group("/")
 	g.GET("/api/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
-	g.GET("/google/testcallback", func(c *gin.Context) {
-		code := c.Query("code")
-		state := c.Query("state")
-		curlCommand := fmt.Sprintf(`curl --request POST \
-  --url 'http://localhost:8080/v1/auth/google/callback' \
-  --header 'Content-Type: application/json' \
-  --cookie 'jan_oauth_state=%s' \
-  --data '{"code": "%s", "state": "%s"}'`, state, code, state)
-		c.String(http.StatusOK, curlCommand)
-	})
 }
 
 func NewHttpServer(v1Route *v1.V1Route) *HttpServer {
@@ -47,6 +36,7 @@ func NewHttpServer(v1Route *v1.V1Route) *HttpServer {
 	// TODO: we should enable cors later
 	server.engine.Use(middleware.CORS())
 	server.engine.Use(middleware.LoggerMiddleware(logger.Logger))
+	server.engine.Use(middleware.TransactionMiddleware())
 	server.engine.GET("/healthcheck", func(c *gin.Context) {
 		c.JSON(200, "ok")
 	})

--- a/apps/jan-api-gateway/application/app/interfaces/http/routes/v1/auth/auth.go
+++ b/apps/jan-api-gateway/application/app/interfaces/http/routes/v1/auth/auth.go
@@ -52,8 +52,6 @@ type AccessTokenResponseObjectType string
 
 const AccessTokenResponseObjectTypeObject = "access.token"
 
-const AccessTokenExpirationDuration = 15 * time.Minute
-
 type AccessTokenResponse struct {
 	Object      AccessTokenResponseObjectType `json:"object"`
 	AccessToken string                        `json:"access_token"`
@@ -164,7 +162,7 @@ func (authRoute *AuthRoute) RefreshToken(reqCtx *gin.Context) {
 		userClaim.ID = user.PublicID
 	}
 
-	accessTokenExp := time.Now().Add(AccessTokenExpirationDuration)
+	accessTokenExp := time.Now().Add(auth.AccessTokenExpirationDuration)
 	accessTokenString, err := auth.CreateJwtSignedString(auth.UserClaim{
 		Email: userClaim.Email,
 		Name:  userClaim.Name,
@@ -253,7 +251,7 @@ func (authRoute *AuthRoute) GuestLogin(reqCtx *gin.Context) {
 		id = userClaim.ID
 	}
 
-	accessTokenExp := time.Now().Add(AccessTokenExpirationDuration)
+	accessTokenExp := time.Now().Add(auth.AccessTokenExpirationDuration)
 	accessTokenString, err := auth.CreateJwtSignedString(auth.UserClaim{
 		Email: email,
 		Name:  name,


### PR DESCRIPTION
- Centralize AccessTokenExpirationDuration and RefreshTokenExpirationDuration in one location.
- Remove test endpoint
- Remove unnecessary code.
