### PR TITLE
Small fix to replace default conv title

### DIFF
--- a/apps/jan-api-gateway/application/app/interfaces/http/routes/v1/conv/conv_completion_route.go
+++ b/apps/jan-api-gateway/application/app/interfaces/http/routes/v1/conv/conv_completion_route.go
@@ -220,6 +220,10 @@ func (api *ConvCompletionAPI) handleConversationManagement(reqCtx *gin.Context, 
 		if convErr != nil {
 			return nil, false, convErr
 		}
+		if conv.Title == nil || *conv.Title == "" || *conv.Title == DefaultConversationTitle {
+			title := api.generateTitleFromMessages(messages)
+			conv.Title = &title
+		}
 		return conv, false, nil
 	} else {
 		// Create new conversation


### PR DESCRIPTION
When client create the conversation with default name.
We will replace the conv title by message data.