### PR TITLE
chore: add ci for stag

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,7 +5,7 @@ on:
       - dev
     paths:
       - "apps/jan-api-gateway/**"
-      - .github/workflows/dev-jan-api-gateway
+      - .github/workflows/dev.yaml
       - .github/workflows/template-docker.yml
   pull_request:
     branches:

--- a/.github/workflows/stag.yml
+++ b/.github/workflows/stag.yml
@@ -1,0 +1,23 @@
+name: CI - jan-api-gateway
+on:
+  push:
+    branches:
+      - stag
+    paths:
+      - "apps/jan-api-gateway/**"
+      - .github/workflows/stag.yaml
+      - .github/workflows/template-docker.yml
+
+jobs:
+  build-docker-x64:
+    uses: ./.github/workflows/template-docker.yml
+    secrets: inherit
+    with:
+      runs-on: ubuntu-24-04-docker
+      docker-file: apps/jan-api-gateway/Dockerfile
+      context: apps/jan-api-gateway
+      registry-url: registry.menlo.ai
+      tags: registry.menlo.ai/jan-server/jan-api-gateway:stag-${{ github.sha }}
+      is_push: ${{ github.event_name == 'push' }}
+      build-args: |
+        VERSION_TAG=stag-${{ github.sha }}


### PR DESCRIPTION
This pull request updates the CI workflow configuration for the `jan-api-gateway` project. The main changes involve renaming and updating the development workflow trigger and introducing a new staging workflow for improved environment separation and automation.

**Workflow configuration updates:**

* Renamed the development workflow file from `.github/workflows/dev-jan-api-gateway.yml` to `.github/workflows/dev.yml` and updated the workflow trigger path accordingly to use `.github/workflows/dev.yaml` instead of the old filename.

**New staging workflow:**

* Added a new GitHub Actions workflow file `.github/workflows/stag.yml` that triggers on pushes to the `stag` branch, specifically for changes in the `jan-api-gateway` app or relevant workflow files. This workflow builds and tags a Docker image for the staging environment using the `template-docker.yml` reusable workflow.