### PR TITLE
chore: correct ci trigger path

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,7 +5,7 @@ on:
       - dev
     paths:
       - "apps/jan-api-gateway/**"
-      - .github/workflows/dev.yaml
+      - .github/workflows/dev.yml
       - .github/workflows/template-docker.yml
   pull_request:
     branches:

--- a/.github/workflows/stag.yml
+++ b/.github/workflows/stag.yml
@@ -5,7 +5,7 @@ on:
       - stag
     paths:
       - "apps/jan-api-gateway/**"
-      - .github/workflows/stag.yaml
+      - .github/workflows/stag.yml
       - .github/workflows/template-docker.yml
 
 jobs:


### PR DESCRIPTION
This pull request updates the workflow configuration files to ensure the correct workflow files are referenced in GitHub Actions triggers. The changes address inconsistencies in file extensions for workflow files, switching from `.yaml` to `.yml` to match the actual filenames.

Workflow configuration fixes:

* Updated the `paths` in `.github/workflows/dev.yml` to reference `.github/workflows/dev.yml` instead of `.github/workflows/dev.yaml`, ensuring the workflow triggers correctly on changes.
* Updated the `paths` in `.github/workflows/stag.yml` to reference `.github/workflows/stag.yml` instead of `.github/workflows/stag.yaml`, ensuring the workflow triggers correctly on changes.