### PR TITLE
chore: correct ci trigger path (#161)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,7 +5,7 @@ on:
       - dev
     paths:
       - "apps/jan-api-gateway/**"
-      - .github/workflows/dev.yaml
+      - .github/workflows/dev.yml
       - .github/workflows/template-docker.yml
   pull_request:
     branches:

--- a/.github/workflows/stag.yml
+++ b/.github/workflows/stag.yml
@@ -5,7 +5,7 @@ on:
       - stag
     paths:
       - "apps/jan-api-gateway/**"
-      - .github/workflows/stag.yaml
+      - .github/workflows/stag.yml
       - .github/workflows/template-docker.yml
 
 jobs:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to ensure the correct workflow files are monitored for changes. Specifically, it fixes the file extensions in the workflow triggers from `.yaml` to `.yml` for consistency and accuracy.

Workflow configuration fixes:

* [`.github/workflows/dev.yml`](diffhunk://#diff-914da273e1d936250929f1160bdd8be46aa865099502b04b471fe734f6b644ddL8-R8): Changed the monitored workflow file from `.github/workflows/dev.yaml` to `.github/workflows/dev.yml` in the `paths` section.
* [`.github/workflows/stag.yml`](diffhunk://#diff-fd4847425a36540efd32fbfa107e6eacfb341e6586fcfe383e5772c1651e4137L8-R8): Changed the monitored workflow file from `.github/workflows/stag.yaml` to `.github/workflows/stag.yml` in the `paths` section.